### PR TITLE
Validate terraform sagemaker configuration

### DIFF
--- a/terraform/sagemaker.tf
+++ b/terraform/sagemaker.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy" "sagemaker_policy" {
 # Resolve a valid SageMaker prebuilt Hugging Face inference image URI (CPU)
 data "aws_sagemaker_prebuilt_ecr_image" "huggingface_cpu" {
   repository_name = "huggingface-pytorch-inference"
-  tag             = "1.13.1-transformers4.30.2-cpu-py39-ubuntu20.04"
+  image_tag       = "1.13.1-transformers4.30.2-cpu-py39-ubuntu20.04"
 }
 
 # SageMaker model
@@ -79,7 +79,7 @@ resource "aws_sagemaker_model" "chatbot" {
 
     environment = {
       HF_MODEL_ID = var.model_name
-      HF_TASK     = "text-generation"
+      HF_TASK     = "question-answering"
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -19,5 +19,5 @@ variable "aws_region" {
 variable "model_name" {
   description = "HuggingFace model name"
   type        = string
-  default     = "microsoft/DialoGPT-medium"
+  default     = "deepset/roberta-base-squad2"
 }


### PR DESCRIPTION
Deploy `deepset/roberta-base-squad2` question-answering model and update Lambda to support QA inputs.

The `image_tag` argument for `aws_sagemaker_prebuilt_ecr_image` was corrected to resolve an `Unsupported argument` error. The Lambda handler was updated to accept explicit `question` and `context` fields for the QA model, with backward compatibility for `message` inputs using a `|||` delimiter.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba1a01d6-3de5-4aea-91c5-86e6a1db6bed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba1a01d6-3de5-4aea-91c5-86e6a1db6bed">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

