### PR TITLE
Check and fix huggingface model terraform error

### DIFF
--- a/terraform/sagemaker.tf
+++ b/terraform/sagemaker.tf
@@ -66,7 +66,7 @@ resource "aws_iam_role_policy" "sagemaker_policy" {
 # Resolve a valid SageMaker prebuilt Hugging Face inference image URI (CPU)
 data "aws_sagemaker_prebuilt_ecr_image" "huggingface_cpu" {
   repository_name = "huggingface-pytorch-inference"
-  tag             = "1.13.1-transformers4.30.2-cpu-py39-ubuntu20.04"
+  image_tag       = "1.13.1-transformers4.30.2-cpu-py39-ubuntu20.04"
 }
 
 # SageMaker model


### PR DESCRIPTION
Replace `tag` with `image_tag` in the `aws_sagemaker_prebuilt_ecr_image` data source to resolve an "Unsupported argument" error during Terraform validation.

---
<a href="https://cursor.com/background-agent?bcId=bc-df08d7fd-a4f6-483a-ac91-9629de3a4067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df08d7fd-a4f6-483a-ac91-9629de3a4067">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

