### PR TITLE
Fix sagemaker model image_uri error

### DIFF
--- a/terraform/sagemaker.tf
+++ b/terraform/sagemaker.tf
@@ -75,7 +75,7 @@ resource "aws_sagemaker_model" "chatbot" {
   execution_role_arn = aws_iam_role.sagemaker_role.arn
 
   primary_container {
-    image = data.aws_sagemaker_prebuilt_ecr_image.huggingface_cpu.image_uri
+    image = data.aws_sagemaker_prebuilt_ecr_image.huggingface_cpu.registry_path
 
     environment = {
       HF_MODEL_ID = var.model_name


### PR DESCRIPTION
Fixes Terraform validation error by correcting SageMaker ECR image attribute from `image_uri` to `registry_path`.

---
<a href="https://cursor.com/background-agent?bcId=bc-bff86dd5-ea1e-4afc-92fd-3d02ee0017e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-bff86dd5-ea1e-4afc-92fd-3d02ee0017e6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

