### PR TITLE
Post-test cleanup operations

### DIFF
--- a/.github/workflows/prototype-ci.yml
+++ b/.github/workflows/prototype-ci.yml
@@ -10,6 +10,7 @@ on:
 env:
   AWS_REGION: us-east-1
   PROJECT_NAME: chatbot-saas
+  TEARDOWN_ON_SUCCESS: "false"
 
 jobs:
   test:
@@ -188,6 +189,13 @@ jobs:
         echo "   git clone <repo> && cd chatbot-saas-prototype"
         echo "   export API_GATEWAY_URL=${{ steps.terraform-output.outputs.api_gateway_url }}"
         echo "   cd cli && python3 chatbot_cli.py"
+
+    - name: Tear down infrastructure on success (optional)
+      if: env.TEARDOWN_ON_SUCCESS == 'true'
+      run: |
+        cd terraform
+        terraform destroy -auto-approve
+        echo "🧹 Destroyed infra after successful test"
 
   cleanup-on-failure:
     name: Cleanup on Failure


### PR DESCRIPTION
Add an optional infrastructure teardown step to the CI workflow to manage costs for deployed resources.

This allows for automatic destruction of Terraform-managed infrastructure (e.g., SageMaker endpoints) after a successful deployment, controlled by the `TEARDOWN_ON_SUCCESS` environment variable, which defaults to `false`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6a0a63f6-ab93-4693-abc1-28f85844a22d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6a0a63f6-ab93-4693-abc1-28f85844a22d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

